### PR TITLE
communication works, db vars established, test page shows pertinent info

### DIFF
--- a/easyxdm.module
+++ b/easyxdm.module
@@ -12,6 +12,13 @@ function easyxdm_menu() {
     'access callback' => TRUE,
   );
 
+  $items['easyxdm-provider-script-test'] = array(
+    'title' => 'Fires EasyXDM provider script for EasyXDM Test Page',
+    'page callback' => 'easyxdm_render_provider_script_only_test',
+    'type' => MENU_CALLBACK,
+    'access callback' => TRUE,
+  );
+
   $items['easyxdm-test-page'] = array(
     'title' => 'EasyXDM Test Page',
     'page callback' => 'easyxdm_render_test_page',
@@ -49,23 +56,26 @@ function easyxdm_library() {
  * @return string
  *   EasyXDM consumer JS, with dynamic variables.
  */
-function easyxdm_script_init() {
+function easyxdm_script_exec($remote_url = NULL, $init_msg = NULL, $on_msg_exec = NULL, $test = FALSE) {
   //////////////////////////////////////////////////////////////
   /// USE HTTPS WHEN TRANSMITTING SENSITIVE DATA!
   //////////////////////////////////////////////////////////////
-  $provider_url = variable_get('easyxdm_provider_url', '');
-  // $consumer_exec is stringified JavaScript to be rendered as HTML and then
+  if (!isset($remote_url)) {
+    $remote_url = variable_get('easyxdm_remote_url', '');
+  }
+  if (!isset($init_msg)) {
+    $init_msg = variable_get('easyxdm_init_msg', '');
+  }
+  // $on_msg_exec is stringified JavaScript to be rendered as HTML and then
   // executed when the HTML is processed by the browser. Extreme care must be
   // taken that only trusted developers submit the code which will be executed!
-  $consumer_exec = variable_get('easyxdm_consumer_exec', '');
+  if (!isset($on_msg_exec)) {
+    $on_msg_exec = variable_get('easyxdm_on_msg_exec', '');
+  }
 
-  // @todo Remove these after development.
-  $provider_url = 'http://d7-provider.local/easyxdm-provider-script';
-  $consumer_exec = 'console.info("EasyXDM receipt success!");';
-
-  // Back our regularly scheduled program. @todo Remove this comment after development.
+  $init_msg = addslashes($init_msg);
   $js = <<<EOT
-    (function (Drupal) {
+    (function (Drupal, $) {
       'use strict';
 
       Drupal.easyXDM = Drupal.easyXDM || {};
@@ -73,45 +83,65 @@ function easyxdm_script_init() {
       // Check whether logged in on other domain.
       if (easyXDM && easyXDM.constructor === Object) {
         var socket = new easyXDM.Socket({
-          remote: '$provider_url',
-          onMessage: function (message) {
+          remote: '$remote_url',
+          onMessage: function (message, origin) {
             // Write the received message to the global Drupal object to be
             // accessed from JavaScripts in custom themes and modules.
             Drupal.easyXDM.inbox = message;
-            $consumer_exec
+            $on_msg_exec
           },
           onReady: function () {
-            socket.postMessage('EasyXDM post success!');
+            if ('$init_msg' !== '') { 
+              socket.postMessage('$init_msg');
+            }
           }
         });
       }
-console.info('easyxdm_script_init');
-console.info(Drupal.easyXDM);
-    })(Drupal);
+    })(Drupal, jQuery);
 EOT;
 
   return $js;
 }
 
 function easyxdm_render_provider_script_only() {
+  global $base_url;
+
   drupal_add_library('easyxdm', 'easyxdm');
-  drupal_add_js(easyxdm_script_init(), array('type' => 'inline'));
+  drupal_add_js(easyxdm_script_exec(), array('type' => 'inline'));
+
+  return '';
+}
+
+function easyxdm_render_provider_script_only_test() {
+  global $base_url;
+
+  drupal_add_library('easyxdm', 'easyxdm');
+  $on_msg_exec = <<<EOT
+    if (message.indexOf("Sending consumer message from ") === 0) {
+      socket.postMessage("Responding with provider message from $base_url");
+    }
+EOT;
+  drupal_add_js(easyxdm_script_exec(NULL, NULL, $on_msg_exec), array('type' => 'inline'));
 
   return '';
 }
 
 function easyxdm_render_test_page() {
+  global $base_url;
+  global $conf;
+
   drupal_add_library('easyxdm', 'easyxdm');
-  drupal_add_js(easyxdm_script_init(), array('type' => 'inline'));
+  // @todo Make these generic after development.
+  $remote_url = 'http://d7-provider.local/easyxdm-provider-script-test';
+  $init_msg = 'Sending consumer message from ' . $base_url;
+  $on_msg_exec = '$("#block-system-main > .content > table > tbody > tr > td:last-child").text(message);';
+  drupal_add_js(easyxdm_script_exec($remote_url, $init_msg, $on_msg_exec), array('type' => 'inline'));
 
-  $output = <<<EOT
-    <script>
-      (function ($) {
-console.info(Object.keys(Drupal));
-console.info(Drupal.easyXDM);
-      })(jQuery);
-    </script>
-EOT;
+  $output = '<h4>X-Frame-Options must be set correctly in order for EasyXDM to communicate across domains.</h4>';
+  $output .= '<h4>$conf[\'x_frame_options\']: ';
+  $output .= !empty($conf['x_frame_options']) ? $conf['x_frame_options'] : '';
+  $output .= '</h4>';
+  $output .= theme('table', array('header'=>array('Message sent', 'Message received'), 'rows'=>array(array($init_msg, ''))));
 
-  return theme('table', array('header'=>array('$header'), 'rows'=>array(array($output))));
+  return $output;
 }

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -8,14 +8,14 @@ function easyxdm_menu() {
 
   if ($is_provider) {
     $items['easyxdm-provider-script'] = array(
-      'title' => 'Page reserved for firing easyXDM provider script',
+      'title' => 'Page reserved for firing easyXDM Provider script',
       'page callback' => 'easyxdm_render_provider_script_only',
       'type' => MENU_CALLBACK,
       'access callback' => TRUE,
     );
 
     $items['easyxdm-provider-script-test'] = array(
-      'title' => 'Fires easyXDM provider script for easyXDM Test Page',
+      'title' => 'Fires easyXDM Provider script for easyXDM Test Page',
       'page callback' => 'easyxdm_render_provider_script_only_test',
       'type' => MENU_CALLBACK,
       'access callback' => TRUE,
@@ -57,7 +57,7 @@ function easyxdm_library() {
  * can easily include dynamic values.
  *
  * @return string
- *   easyXDM consumer JS, with dynamic variables.
+ *   easyXDM Consumer JS, with dynamic variables.
  */
 function easyxdm_script_exec($remote_url = NULL, $init_msg = NULL, $on_msg_exec = NULL, $test = FALSE) {
   //////////////////////////////////////////////////////////////
@@ -121,8 +121,8 @@ function easyxdm_render_provider_script_only_test() {
   drupal_add_library('easyxdm', 'easyxdm');
 
   $on_msg_exec = <<<EOT
-    if (message.indexOf("Sending consumer message from ") === 0) {
-      socket.postMessage("Responding with provider message from $base_url");
+    if (message.indexOf("Sending Consumer message from ") === 0) {
+      socket.postMessage("Responding with Provider message from $base_url");
     }
 EOT;
 
@@ -138,36 +138,41 @@ function easyxdm_render_test_page() {
   drupal_add_library('easyxdm', 'easyxdm');
 
   $remote_url = NULL;
-  $consumer_msg = 'Sending consumer message from ' . $base_url;
+  $consumer_msg = 'Sending Consumer message from ' . $base_url;
   $on_msg_exec = '$("#block-system-main > .content > table > tbody > tr > td:last-child").text(message);';
 
   drupal_add_js(easyxdm_script_exec($remote_url, $consumer_msg, $on_msg_exec), array('type' => 'inline'));
 
-  $output = '<h4>X-Frame-Options must be set correctly in order for easyXDM providers to communicate across domains.</h4>';
-  $output .= '<h4>$conf[\'x_frame_options\']: ';
+  $output = '<h4>X-Frame-Options must be set correctly in order for easyXDM Providers to communicate across domains.</h4>';
+  $output .= '<blockquote>$conf[\'x_frame_options\']: ';
   $output .= !empty($conf['x_frame_options']) ? $conf['x_frame_options'] : '';
-  $output .= '</h4>';
+  $output .= '</blockquote>';
 
   $is_provider = variable_get('easyxdm_provide', FALSE);
-  $output .= '<h4>easyxdm_provide must be TRUE on providers.</h4>';
-  $output .= '<h4>DB var easyxdm_provide: ';
+  $output .= '<h4>easyxdm_provide must be TRUE on Providers.</h4>';
+  $output .= '<blockquote>DB var easyxdm_provide: ';
   $output .= $is_provider ? 'TRUE' : 'FALSE';
-  $output .= '</h4>';
+  $output .= '</blockquote>';
 
   $remote_url = variable_get('easyxdm_remote_url', '');
-  $output .= '<h4>easyxdm_remote_url must point to a valid easyXDM provider page on consumers.</h4>';
-  $output .= '<h4>DB var easyxdm_remote_url: ';
+  $output .= '<h4>easyxdm_remote_url must point to a valid easyXDM Provider page on Consumers.</h4>';
+  $output .= '<blockquote>DB var easyxdm_remote_url: ';
   $output .= $remote_url;
-  $output .= '</h4>';
+  $output .= '</blockquote>';
 
   $init_msg = variable_get('easyxdm_init_msg', '');
-  $output .= '<h4>DB var easyxdm_init_msg: ';
+  $output .= '<h4>easyxdm_init_msg is configurable in the DB for convenience.<br>';
+  $output .= 'It can also be passed as a param when Consumers call easyxdm_script_exec</h4>';
+  $output .= '<blockquote>DB var easyxdm_init_msg: ';
   $output .= $init_msg;
-  $output .= '</h4>';
+  $output .= '</blockquote>';
 
   $on_msg_exec = variable_get('easyxdm_on_msg_exec', '');
-  $output .= '<h4>DB var easyxdm_on_msg_exec:</h4>';
-  $output .= '<h4>' . $on_msg_exec . '</h4>';
+  $output .= '<h4>easyxdm_on_msg_exec is necessary on Providers. It must be stringified JavaScript and can key off of<br>';
+  $output .= 'the easyxdm_init_msg sent from the Consumer.</h4>';
+  $output .= '<blockquote>DB var easyxdm_on_msg_exec: ';
+  $output .= $on_msg_exec;
+  $output .= '</blockquote>';
 
   $output .= theme('table', array('header'=>array('Message sent', 'Message received'), 'rows'=>array(array($consumer_msg, ''))));
 

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -149,13 +149,13 @@ function easyxdm_render_test_page() {
   $output .= '</h4>';
 
   $is_provider = variable_get('easyxdm_provide', FALSE);
-  $output .= '<h4>easy_provide must be TRUE on providers.</h4>';
+  $output .= '<h4>easyxdm_provide must be TRUE on providers.</h4>';
   $output .= '<h4>DB var easyxdm_provide: ';
   $output .= $is_provider ? 'TRUE' : 'FALSE';
   $output .= '</h4>';
 
   $remote_url = variable_get('easyxdm_remote_url', '');
-  $output .= '<h4>easy_remote_url must point to a valid EasyXDM provider page on consumers.</h4>';
+  $output .= '<h4>easyxdm_remote_url must point to a valid EasyXDM provider page on consumers.</h4>';
   $output .= '<h4>DB var easyxdm_remote_url: ';
   $output .= $remote_url;
   $output .= '</h4>';

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -161,8 +161,8 @@ function easyxdm_render_test_page() {
   $output .= '</blockquote>';
 
   $init_msg = variable_get('easyxdm_init_msg', '');
-  $output .= '<h4>easyxdm_init_msg is configurable in the DB for convenience.<br>';
-  $output .= 'It can also be passed as a param when Consumers call easyxdm_script_exec</h4>';
+  $output .= '<h4>easyxdm_init_msg is configurable in the DB for convenience. It can also be passed as a param when<br>';
+  $output .= 'Consumers call easyxdm_script_exec().</h4>';
   $output .= '<blockquote>DB var easyxdm_init_msg: ';
   $output .= $init_msg;
   $output .= '</blockquote>';

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -5,10 +5,16 @@
 function easyxdm_menu() {
   $items = array();
 
-  // @todo Improve this.
+  $items['easyxdm-provider-script'] = array(
+    'title' => 'Page reserved for firing EasyXDM provider script',
+    'page callback' => 'easyxdm_render_provider_script_only',
+    'type' => MENU_CALLBACK,
+    'access callback' => TRUE,
+  );
+
   $items['easyxdm-test-page'] = array(
     'title' => 'EasyXDM Test Page',
-    'page callback' => 'easyxdm_test_page',
+    'page callback' => 'easyxdm_render_test_page',
     'type' => MENU_CALLBACK,
     'access callback' => TRUE,
   );
@@ -45,10 +51,19 @@ function easyxdm_library() {
  */
 function easyxdm_script_init() {
   //////////////////////////////////////////////////////////////
-  /// USE HTTPS WHEN SENDING SENSITIVE DATA!
+  /// USE HTTPS WHEN TRANSMITTING SENSITIVE DATA!
   //////////////////////////////////////////////////////////////
-  // @todo Make this variable.
-  $provider_remote = 'http://d7-provider.local';
+  $provider_url = variable_get('easyxdm_provider_url', '');
+  // $consumer_exec is stringified JavaScript to be rendered as HTML and then
+  // executed when the HTML is processed by the browser. Extreme care must be
+  // taken that only trusted developers submit the code which will be executed!
+  $consumer_exec = variable_get('easyxdm_consumer_exec', '');
+
+  // @todo Remove these after development.
+  $provider_url = 'http://d7-provider.local/easyxdm-provider-script';
+  $consumer_exec = 'console.info("EasyXDM receipt success!");';
+
+  // Back our regularly scheduled program. @todo Remove this comment after development.
   $js = <<<EOT
     (function (Drupal) {
       'use strict';
@@ -58,15 +73,15 @@ function easyxdm_script_init() {
       // Check whether logged in on other domain.
       if (easyXDM && easyXDM.constructor === Object) {
         var socket = new easyXDM.Socket({
-          remote: '$provider_remote',
+          remote: '$provider_url',
           onMessage: function (message) {
-            // Write the received message to the global Drupal object to be used elsewhere on the site
-            drupalEasyXDM.messageConsumed = message;
-/*
+            // Write the received message to the global Drupal object to be
+            // accessed from JavaScripts in custom themes and modules.
+            Drupal.easyXDM.inbox = message;
+            $consumer_exec
           },
           onReady: function () {
-            socket.postMessage('');
-*/
+            socket.postMessage('EasyXDM post success!');
           }
         });
       }
@@ -78,7 +93,14 @@ EOT;
   return $js;
 }
 
-function easyxdm_test_page() {
+function easyxdm_render_provider_script_only() {
+  drupal_add_library('easyxdm', 'easyxdm');
+  drupal_add_js(easyxdm_script_init(), array('type' => 'inline'));
+
+  return '';
+}
+
+function easyxdm_render_test_page() {
   drupal_add_library('easyxdm', 'easyxdm');
   drupal_add_js(easyxdm_script_init(), array('type' => 'inline'));
 

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -8,14 +8,14 @@ function easyxdm_menu() {
 
   if ($is_provider) {
     $items['easyxdm-provider-script'] = array(
-      'title' => 'Page reserved for firing EasyXDM provider script',
+      'title' => 'Page reserved for firing easyXDM provider script',
       'page callback' => 'easyxdm_render_provider_script_only',
       'type' => MENU_CALLBACK,
       'access callback' => TRUE,
     );
 
     $items['easyxdm-provider-script-test'] = array(
-      'title' => 'Fires EasyXDM provider script for EasyXDM Test Page',
+      'title' => 'Fires easyXDM provider script for easyXDM Test Page',
       'page callback' => 'easyxdm_render_provider_script_only_test',
       'type' => MENU_CALLBACK,
       'access callback' => TRUE,
@@ -23,7 +23,7 @@ function easyxdm_menu() {
   }
 
   $items['easyxdm-test-page'] = array(
-    'title' => 'EasyXDM Test Page',
+    'title' => 'easyXDM Test Page',
     'page callback' => 'easyxdm_render_test_page',
     'type' => MENU_CALLBACK,
     'access callback' => TRUE,
@@ -39,7 +39,7 @@ function easyxdm_library() {
   $libraries = array();
 
   $libraries['easyxdm'] = array(
-    'title' => 'EasyXDM',
+    'title' => 'easyXDM',
     'website' => 'http://easyxdm.net/',
     'version' => '2.4.20.7',
     'js' => array(
@@ -51,13 +51,13 @@ function easyxdm_library() {
 }
 
 /**
- * JS to initialize EasyXDM with the capacity to send and receive messages.
+ * JS to initialize easyXDM with the capacity to send and receive messages.
  *
  * Note define the JS string here, rather than a traditional JS file, so that we
  * can easily include dynamic values.
  *
  * @return string
- *   EasyXDM consumer JS, with dynamic variables.
+ *   easyXDM consumer JS, with dynamic variables.
  */
 function easyxdm_script_exec($remote_url = NULL, $init_msg = NULL, $on_msg_exec = NULL, $test = FALSE) {
   //////////////////////////////////////////////////////////////
@@ -143,7 +143,7 @@ function easyxdm_render_test_page() {
 
   drupal_add_js(easyxdm_script_exec($remote_url, $consumer_msg, $on_msg_exec), array('type' => 'inline'));
 
-  $output = '<h4>X-Frame-Options must be set correctly in order for EasyXDM providers to communicate across domains.</h4>';
+  $output = '<h4>X-Frame-Options must be set correctly in order for easyXDM providers to communicate across domains.</h4>';
   $output .= '<h4>$conf[\'x_frame_options\']: ';
   $output .= !empty($conf['x_frame_options']) ? $conf['x_frame_options'] : '';
   $output .= '</h4>';
@@ -155,7 +155,7 @@ function easyxdm_render_test_page() {
   $output .= '</h4>';
 
   $remote_url = variable_get('easyxdm_remote_url', '');
-  $output .= '<h4>easyxdm_remote_url must point to a valid EasyXDM provider page on consumers.</h4>';
+  $output .= '<h4>easyxdm_remote_url must point to a valid easyXDM provider page on consumers.</h4>';
   $output .= '<h4>DB var easyxdm_remote_url: ';
   $output .= $remote_url;
   $output .= '</h4>';

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -4,20 +4,23 @@
  */
 function easyxdm_menu() {
   $items = array();
+  $is_provider = variable_get('easyxdm_provide', FALSE);
 
-  $items['easyxdm-provider-script'] = array(
-    'title' => 'Page reserved for firing EasyXDM provider script',
-    'page callback' => 'easyxdm_render_provider_script_only',
-    'type' => MENU_CALLBACK,
-    'access callback' => TRUE,
-  );
+  if ($is_provider) {
+    $items['easyxdm-provider-script'] = array(
+      'title' => 'Page reserved for firing EasyXDM provider script',
+      'page callback' => 'easyxdm_render_provider_script_only',
+      'type' => MENU_CALLBACK,
+      'access callback' => TRUE,
+    );
 
-  $items['easyxdm-provider-script-test'] = array(
-    'title' => 'Fires EasyXDM provider script for EasyXDM Test Page',
-    'page callback' => 'easyxdm_render_provider_script_only_test',
-    'type' => MENU_CALLBACK,
-    'access callback' => TRUE,
-  );
+    $items['easyxdm-provider-script-test'] = array(
+      'title' => 'Fires EasyXDM provider script for EasyXDM Test Page',
+      'page callback' => 'easyxdm_render_provider_script_only_test',
+      'type' => MENU_CALLBACK,
+      'access callback' => TRUE,
+    );
+  }
 
   $items['easyxdm-test-page'] = array(
     'title' => 'EasyXDM Test Page',
@@ -116,11 +119,13 @@ function easyxdm_render_provider_script_only_test() {
   global $base_url;
 
   drupal_add_library('easyxdm', 'easyxdm');
+
   $on_msg_exec = <<<EOT
     if (message.indexOf("Sending consumer message from ") === 0) {
       socket.postMessage("Responding with provider message from $base_url");
     }
 EOT;
+
   drupal_add_js(easyxdm_script_exec(NULL, NULL, $on_msg_exec), array('type' => 'inline'));
 
   return '';
@@ -131,17 +136,40 @@ function easyxdm_render_test_page() {
   global $conf;
 
   drupal_add_library('easyxdm', 'easyxdm');
-  // @todo Make these generic after development.
-  $remote_url = 'http://d7-provider.local/easyxdm-provider-script-test';
-  $init_msg = 'Sending consumer message from ' . $base_url;
-  $on_msg_exec = '$("#block-system-main > .content > table > tbody > tr > td:last-child").text(message);';
-  drupal_add_js(easyxdm_script_exec($remote_url, $init_msg, $on_msg_exec), array('type' => 'inline'));
 
-  $output = '<h4>X-Frame-Options must be set correctly in order for EasyXDM to communicate across domains.</h4>';
+  $remote_url = NULL;
+  $consumer_msg = 'Sending consumer message from ' . $base_url;
+  $on_msg_exec = '$("#block-system-main > .content > table > tbody > tr > td:last-child").text(message);';
+
+  drupal_add_js(easyxdm_script_exec($remote_url, $consumer_msg, $on_msg_exec), array('type' => 'inline'));
+
+  $output = '<h4>X-Frame-Options must be set correctly in order for EasyXDM providers to communicate across domains.</h4>';
   $output .= '<h4>$conf[\'x_frame_options\']: ';
   $output .= !empty($conf['x_frame_options']) ? $conf['x_frame_options'] : '';
   $output .= '</h4>';
-  $output .= theme('table', array('header'=>array('Message sent', 'Message received'), 'rows'=>array(array($init_msg, ''))));
+
+  $is_provider = variable_get('easyxdm_provide', FALSE);
+  $output .= '<h4>easy_provide must be TRUE on providers.</h4>';
+  $output .= '<h4>DB var easyxdm_provide: ';
+  $output .= $is_provider ? 'TRUE' : 'FALSE';
+  $output .= '</h4>';
+
+  $remote_url = variable_get('easyxdm_remote_url', '');
+  $output .= '<h4>easy_remote_url must point to a valid EasyXDM provider page on consumers.</h4>';
+  $output .= '<h4>DB var easyxdm_remote_url: ';
+  $output .= $remote_url;
+  $output .= '</h4>';
+
+  $init_msg = variable_get('easyxdm_init_msg', '');
+  $output .= '<h4>DB var easyxdm_init_msg: ';
+  $output .= $init_msg;
+  $output .= '</h4>';
+
+  $on_msg_exec = variable_get('easyxdm_on_msg_exec', '');
+  $output .= '<h4>DB var easyxdm_on_msg_exec:</h4>';
+  $output .= '<h4>' . $on_msg_exec . '</h4>';
+
+  $output .= theme('table', array('header'=>array('Message sent', 'Message received'), 'rows'=>array(array($consumer_msg, ''))));
 
   return $output;
 }

--- a/easyxdm.module
+++ b/easyxdm.module
@@ -133,7 +133,6 @@ EOT;
 
 function easyxdm_render_test_page() {
   global $base_url;
-  global $conf;
 
   drupal_add_library('easyxdm', 'easyxdm');
 
@@ -143,36 +142,30 @@ function easyxdm_render_test_page() {
 
   drupal_add_js(easyxdm_script_exec($remote_url, $consumer_msg, $on_msg_exec), array('type' => 'inline'));
 
+  $x_frame_options = variable_get('x_frame_options', '');
   $output = '<h4>X-Frame-Options must be set correctly in order for easyXDM Providers to communicate across domains.</h4>';
-  $output .= '<blockquote>$conf[\'x_frame_options\']: ';
-  $output .= !empty($conf['x_frame_options']) ? $conf['x_frame_options'] : '';
-  $output .= '</blockquote>';
+  $output .= '<blockquote>$conf[\'x_frame_options\']: ' . $x_frame_options . '</blockquote>';
 
   $is_provider = variable_get('easyxdm_provide', FALSE);
   $output .= '<h4>easyxdm_provide must be TRUE on Providers.</h4>';
-  $output .= '<blockquote>DB var easyxdm_provide: ';
+  $output .= '<blockquote>$conf[\'easyxdm_provide\']: ';
   $output .= $is_provider ? 'TRUE' : 'FALSE';
   $output .= '</blockquote>';
 
   $remote_url = variable_get('easyxdm_remote_url', '');
   $output .= '<h4>easyxdm_remote_url must point to a valid easyXDM Provider page on Consumers.</h4>';
-  $output .= '<blockquote>DB var easyxdm_remote_url: ';
-  $output .= $remote_url;
-  $output .= '</blockquote>';
+  $output .= '<blockquote>$conf[\'easyxdm_remote_url\']: ' . $remote_url . '</blockquote>';
 
   $init_msg = variable_get('easyxdm_init_msg', '');
-  $output .= '<h4>easyxdm_init_msg is configurable in the DB for convenience. It can also be passed as a param when<br>';
-  $output .= 'Consumers call easyxdm_script_exec().</h4>';
-  $output .= '<blockquote>DB var easyxdm_init_msg: ';
-  $output .= $init_msg;
-  $output .= '</blockquote>';
+  $output .= '<h4>easyxdm_init_msg is configurable for single-case use or default cases. It might more often need to<br>';
+  $output .= 'be passed as a param when Consumers call easyxdm_script_exec().</h4>';
+  $output .= '<blockquote>$conf[\'easyxdm_init_msg\']: ' . $init_msg . '</blockquote>';
 
   $on_msg_exec = variable_get('easyxdm_on_msg_exec', '');
   $output .= '<h4>easyxdm_on_msg_exec is necessary on Providers. It must be stringified JavaScript and can key off of<br>';
-  $output .= 'the easyxdm_init_msg sent from the Consumer.</h4>';
-  $output .= '<blockquote>DB var easyxdm_on_msg_exec: ';
-  $output .= $on_msg_exec;
-  $output .= '</blockquote>';
+  $output .= 'the easyxdm_init_msg sent from the Consumer for different cases.<br>';
+  $output .= '<strong>Extreme care must be taken that only trusted developers submit the code which will be executed!</strong></h4>';
+  $output .= '<blockquote>$conf[\'easyxdm_on_msg_exec\']: ' . $on_msg_exec . '</blockquote>';
 
   $output .= theme('table', array('header'=>array('Message sent', 'Message received'), 'rows'=>array(array($consumer_msg, ''))));
 


### PR DESCRIPTION
@scottrigby The description pretty well describes what's happening thus far. To test this:
* create 2 D7 sites locally
* open up the provider's X-Frame-Options (ALLOWALL is fine locally)
* set the appropriate db vars on both the consumer and provider
  * `easyxdm_provide` must be TRUE on providers
  * `easyxdm_remote_url` must point to a valid EasyXDM provider page on consumers
  * /easyxdm-provider-script is the path for provider pages
* view /easyxdm-test-page on both sites to check that everything works
* consumer should show both Message sent and Message received
* provider should only show Message sent